### PR TITLE
[META-53] Update verify-pr-action Version

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Check
-        uses: pczern/verify-pr-action@v0.0.3-alpha.29
+        uses: pczern/verify-pr-action@v0.0.3-alpha.38
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           titleRegex: "\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+"


### PR DESCRIPTION
### Description
The updated version of [verify-pr-action](https://github.com/pczern/verify-pr-action) uses less GitHub API Calls, adds a `Verified` label, and also removes `Merge Conflict` label if there are none; also now is able to enforce min length (there was a bug as input in actions was string and not integer)

### How I implemented
* Update the version to verify-pr-action@v0.0.3-alpha.38 by ad