### PR TITLE
[META-51] Auth workaround

### DIFF
--- a/packages/graphql_gateway/src/envelopPlugins.ts
+++ b/packages/graphql_gateway/src/envelopPlugins.ts
@@ -1,7 +1,7 @@
-import { useGenericAuth, ResolveUserFn } from '@envelop/generic-auth'
-import { createClient, User } from '@supabase/supabase-js'
-import { IncomingMessage } from 'http'
+import { ResolveUserFn, useGenericAuth } from '@envelop/generic-auth'
+import { User, createClient } from '@supabase/supabase-js'
 import { parse } from 'cookie'
+import { IncomingMessage } from 'http'
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_API_KEY)
 
@@ -10,23 +10,29 @@ type Context = {
 }
 
 const resolveUserFn: ResolveUserFn<User, Context> = async (context: Context) => {
-  if (!context?.req?.headers?.cookie) {
-    console.error('All Cookies missing')
+  // Get cookies from authorization header (temporary workaround)
+  const cookies = parse(context?.req?.headers?.authorization as string)
+
+  if (!cookies?.['supabase-auth-token']) {
+    console.error('Auth token missing')
     return null
   }
-  const cookies = parse(context.req.headers.cookie)
-  if (!cookies?.jwt) {
-    console.error('Jwt cookie missing')
-    return null
-  }
+
+  // Get JWT from cookie (cookie set by Supabase is array of tokens)
+  const tokenArray: string[] = JSON.parse(cookies?.['supabase-auth-token']) as string[]
+  const jwt = tokenArray[0]
+
+  // Get user from Supabase if JWT is valid
   const {
     data: { user },
     error
-  } = await supabase.auth.getUser(cookies?.jwt)
+  } = await supabase.auth.getUser(jwt)
+
   if (error) {
-    console.error('Error when getting user from Supabase', error)
+    console.error('Error while trying to get user from Supabase', error)
     return null
   }
+
   return user
 }
 
@@ -36,4 +42,5 @@ const plugins = [
     mode: 'protect-all'
   })
 ]
+
 export default plugins

--- a/packages/graphql_gateway/src/envelopPlugins.ts
+++ b/packages/graphql_gateway/src/envelopPlugins.ts
@@ -20,7 +20,7 @@ const resolveUserFn: ResolveUserFn<User, Context> = async (context: Context) => 
 
   // Get JWT from cookie (cookie set by Supabase is array of tokens)
   const tokenArray: string[] = JSON.parse(cookies?.['supabase-auth-token']) as string[]
-  const jwt = tokenArray[0]
+  const jwt = tokenArray?.[0]
 
   // Get user from Supabase if JWT is valid
   const {


### PR DESCRIPTION
### Description of issue
Get auth token from custom header instead of cookie (temporary workaround)
Why? We currently can't send the token via cookie because frontend and backend have different domains.

### How I implemented
See `graphql_gateway/src/envelopPlugins.ts`

### Other
This change can be undone once we have bought & set up a domain both applications can use.