### PR TITLE
[META-80] Fix deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,23 +38,23 @@ jobs:
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - name: Update values in deployment file
         run: >
-          COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) && 
-          GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) && 
-          GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) && 
-          CHANGE_CAUSE=${{github.event.head_commit.message}} && 
-          GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} && 
-          GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} && 
-          REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} && 
-          CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) && 
-          sed -i '
-          s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
+          COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
+          GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
+          GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo "${{github.event.head_commit.message}}" | tr '\n' ' ' | xargs)" &&
+          GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
+          GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
+          REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
+          CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
+          sed -i
+          's|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-          s|<CHANGE_CAUSE>|'${CHANGE_CAUSE}'|;
-          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|
-          ' $GITHUB_WORKSPACE/config/deployment.yml
+          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
+          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|'
+          $GITHUB_WORKSPACE/config/deployment.yml
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
       - name: Verify deployment


### PR DESCRIPTION
### Description
The deployment of #39 failed because of
```
COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&  GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&  GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&  CHANGE_CAUSE=Merge pull request #39 from jst-seminar-rostlab-tum/META-78
  
  [META-78] Add SSL certificate to Kubernetes &&  GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&  GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&  REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&  CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&  sed -i ' s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|; s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|; s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|; s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|; s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|; s|<CHANGE_CAUSE>|'${CHANGE_CAUSE}'|; s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'| ' $GITHUB_WORKSPACE/config/deployment.yml
```
the command was malformed, this PR intends to solve that.

### How I implemented
Remove all new lines, add commit sha part to change cause, trim commit message in change cause