### PR TITLE
[META-80] Fix deployment, with CHANGE-CAUSE, use Node to replace variables instead of sed

### DIFF
--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -1,0 +1,17 @@
+const fs = require('fs')
+const deploymentFile = '../config/deployment.yml'
+try {
+  const data = fs
+    .readFileSync(deploymentFile, 'utf8')
+    .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
+    .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
+    .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
+    .replace('<CHANGE-CAUSE>', process.env.CHANGE_CAUSE)
+    .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
+    .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
+    .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
+  fs.writeFileSync(deploymentFile, data)
+  console.log('Deployment file written')
+} catch (error) {
+  console.error(error)
+}

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -12,7 +12,7 @@ try {
       '<CHANGE-CAUSE>',
       `${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`
     )
-    .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
+    .replace('<GRAPHQL-GATEWAY-PORT>', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
   console.log(data)

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -10,7 +10,7 @@ try {
     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
     .replace(
       '<CHANGE-CAUSE>',
-      `${process.env.COMMIT_TAG}: ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`
+      `'${process.env.COMMIT_TAG}: ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}'`
     )
     .replace('<GRAPHQL-GATEWAY-PORT>', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -1,18 +1,17 @@
 const fs = require('fs')
-console.log(__dirname)
-const deploymentFile = '../config/deployment.yml'
-// try {
-//   const data = fs
-//     .readFileSync(deploymentFile, 'utf8')
-//     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
-//     .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
-//     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
-//     .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
-//     .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
-//     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
-//     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
-//   fs.writeFileSync(deploymentFile, data)
-//   console.log('Deployment file written')
-// } catch (error) {
-//   console.error(error)
-// }
+const deploymentFile = path.join(__dirname, '../config/deployment.yml')
+try {
+  const data = fs
+    .readFileSync(deploymentFile, 'utf8')
+    .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
+    .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
+    .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
+    .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
+    .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
+    .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
+    .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
+  fs.writeFileSync(deploymentFile, data)
+  console.log('Deployment file written')
+} catch (error) {
+  console.error(error)
+}

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 const deploymentFile = path.join(__dirname, '../config/deployment.yml')
 try {
   const data = fs

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -10,7 +10,7 @@ try {
     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
     .replace(
       '<CHANGE-CAUSE>',
-      `${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`
+      `${process.env.COMMIT_TAG}: ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`
     )
     .replace('<GRAPHQL-GATEWAY-PORT>', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const path = require('path')
 const deploymentFile = path.join(__dirname, '../config/deployment.yml')
 try {
-  console.log(`${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`)
   const data = fs
     .readFileSync(deploymentFile, 'utf8')
     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
@@ -15,7 +14,6 @@ try {
     .replace('<GRAPHQL-GATEWAY-PORT>', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
-  console.log(data)
   fs.writeFileSync(deploymentFile, data)
   console.log('Deployment file written')
 } catch (error) {

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -6,7 +6,7 @@ try {
     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
     .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
-    .replace('<CHANGE-CAUSE>', process.env.CHANGE_CAUSE)
+    .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
     .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -7,7 +7,10 @@ try {
     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
     .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
-    .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
+    .replace(
+      '<CHANGE-CAUSE>',
+      `'${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}'`
+    )
     .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -1,17 +1,18 @@
 const fs = require('fs')
+console.log(__dirname)
 const deploymentFile = '../config/deployment.yml'
-try {
-  const data = fs
-    .readFileSync(deploymentFile, 'utf8')
-    .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
-    .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
-    .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
-    .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
-    .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
-    .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
-    .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
-  fs.writeFileSync(deploymentFile, data)
-  console.log('Deployment file written')
-} catch (error) {
-  console.error(error)
-}
+// try {
+//   const data = fs
+//     .readFileSync(deploymentFile, 'utf8')
+//     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
+//     .replace('<GRAPHQL-GATEWAY-IMAGE>', process.env.GRAPHQL_GATEWAY_IMAGE)
+//     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
+//     .replace('<CHANGE-CAUSE>', `'${process.env.CHANGE_CAUSE.replaceAll("'", '')}'`)
+//     .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
+//     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
+//     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
+//   fs.writeFileSync(deploymentFile, data)
+//   console.log('Deployment file written')
+// } catch (error) {
+//   console.error(error)
+// }

--- a/.github/init-deployment.js
+++ b/.github/init-deployment.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const deploymentFile = path.join(__dirname, '../config/deployment.yml')
 try {
+  console.log(`${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`)
   const data = fs
     .readFileSync(deploymentFile, 'utf8')
     .replace('<GRAPHQL-SERVER-IMAGE>', process.env.GRAPHQL_SERVER_IMAGE)
@@ -9,11 +10,12 @@ try {
     .replace('<REPO-JOB-IMAGE>', process.env.REPO_JOB_IMAGE)
     .replace(
       '<CHANGE-CAUSE>',
-      `'${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}'`
+      `${process.env.COMMIT_TAG} ${process.env.COMMIT_MESSAGE.replaceAll("'", '')}`
     )
     .replace('<GRAPHQL-GATEWAY-PORT', process.env.GRAPHQL_GATEWAY_PORT)
     .replace('<GRAPHQL-SERVER-PORT>', process.env.GRAPHQL_SERVER_PORT)
     .replace('<CERTIFICATE-ID>', process.env.CERTIFICATE_ID)
+  console.log(data)
   fs.writeFileSync(deploymentFile, data)
   console.log('Deployment file written')
 } catch (error) {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d '"' | tr '\n' ' ' | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr '\n ' '\ ' | tr -d \'\"\| | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
           CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
-          node ../init-deployment.js
+          node $GITHUB_WORKSPACE/.github/init-deployment.js
 
       # - name: Update values in deployment file
       #   run: >

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,8 @@ jobs:
           CHANGE_CAUSE="test\ test" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
-          sed -e '
-          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
-          s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
+          sed -e
+          's|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')" &&
+          CHANGE_CAUSE='$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,13 @@ jobs:
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
-          sed -i '' -e '
+          sed -e '
           s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;'
+          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
           $GITHUB_WORKSPACE/config/deployment.yml
       # - name: Deploy to DigitalOcean Kubernetes
       #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,19 +42,19 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG):\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e '
+          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
           s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
           s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
           $GITHUB_WORKSPACE/config/deployment.yml
       # - name: Deploy to DigitalOcean Kubernetes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG):\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g')" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG):\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE="test test" &&
+          CHANGE_CAUSE="test\ test" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e '

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE="test\\ test" &&
+          CHANGE_CAUSE='test\\ test' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr '\n ' '\ ' | tr -d \'\"\| | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr '\n ' '\\ ' | tr -d \'\"\| | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo "${{github.event.head_commit.message}}" | tr '\n' ' ' | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo "${{ toJSON(github.event.head_commit.message) }}" | tr '\n' ' ' | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,26 +15,26 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@main
-      # - name: Install doctl
-      #   uses: digitalocean/action-doctl@v2
-      #   with:
-      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       # - name: Build truffle-ai-graphql-gateway image
       #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
       # - name: Build truffle-ai-graphql-server image
       #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
       # - name: Build truffle-ai-repo-job image
       #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
-      # - name: Log in to DigitalOcean Container Registry with short-lived credentials
-      #   run: doctl registry login --expiry-seconds 1200
+      - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        run: doctl registry login --expiry-seconds 1200
       # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
       # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
       # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
-      # - name: Save DigitalOcean kubeconfig with short-lived credentials
-      #   run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
+      - name: Save DigitalOcean kubeconfig with short-lived credentials
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - name: Update values in deployment file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
+          echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -i '' -e '
           s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,26 +15,26 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@main
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Build truffle-ai-graphql-gateway image
-        run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
-      - name: Build truffle-ai-graphql-server image
-        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
-      - name: Build truffle-ai-repo-job image
-        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
-      - name: Log in to DigitalOcean Container Registry with short-lived credentials
-        run: doctl registry login --expiry-seconds 1200
-      - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
-      - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
-      - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
-      - name: Save DigitalOcean kubeconfig with short-lived credentials
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
+      # - name: Install doctl
+      #   uses: digitalocean/action-doctl@v2
+      #   with:
+      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      # - name: Build truffle-ai-graphql-gateway image
+      #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
+      # - name: Build truffle-ai-graphql-server image
+      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
+      # - name: Build truffle-ai-repo-job image
+      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
+      # - name: Log in to DigitalOcean Container Registry with short-lived credentials
+      #   run: doctl registry login --expiry-seconds 1200
+      # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
+      # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
+      # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
+      # - name: Save DigitalOcean kubeconfig with short-lived credentials
+      #   run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - name: Update values in deployment file
@@ -56,7 +56,7 @@ jobs:
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
           s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;'
           $GITHUB_WORKSPACE/config/deployment.yml
-      - name: Deploy to DigitalOcean Kubernetes
-        run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
-      - name: Verify deployment
-        run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment
+      # - name: Deploy to DigitalOcean Kubernetes
+      #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
+      # - name: Verify deployment
+      #   run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,11 +47,11 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE='test\\ test' &&
+          CHANGE_CAUSE='test test' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e
-          's|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
+          's|<CHANGE-CAUSE>|'"${CHANGE_CAUSE}"'|;
           s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
       #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
       # - name: Build truffle-ai-repo-job image
       #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
-      # - name: Log in to DigitalOcean Container Registry with short-lived credentials
-      #   run: doctl registry login --expiry-seconds 1200
+      - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        run: doctl registry login --expiry-seconds 1200
       # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
       # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@main
-      # - name: Install doctl
-      #   uses: digitalocean/action-doctl@v2
-      #   with:
-      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       # - name: Build truffle-ai-graphql-gateway image
       #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
       # - name: Build truffle-ai-graphql-server image
@@ -33,10 +33,10 @@ jobs:
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
       # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
-      # - name: Save DigitalOcean kubeconfig with short-lived credentials
-      #   run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
-      # - name: Create deployment.yml from deployment.template.yml and add environment variables
-      #   run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
+      - name: Save DigitalOcean kubeconfig with short-lived credentials
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
+      - name: Create deployment.yml from deployment.template.yml and add environment variables
+        run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - uses: actions/setup-node@v3
       - name: Update values in deployment file
         run: COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE='$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')' &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,20 +19,20 @@ jobs:
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      # - name: Build truffle-ai-graphql-gateway image
-      #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
-      # - name: Build truffle-ai-graphql-server image
-      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
-      # - name: Build truffle-ai-repo-job image
-      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
+      - name: Build truffle-ai-graphql-gateway image
+        run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
+      - name: Build truffle-ai-graphql-server image
+        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
+      - name: Build truffle-ai-repo-job image
+        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
         run: doctl registry login --expiry-seconds 1200
-      # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
-      # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
-      # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
+      - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
+      - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
+      - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
@@ -48,7 +48,7 @@ jobs:
           CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           node $GITHUB_WORKSPACE/.github/init-deployment.js
-      # - name: Deploy to DigitalOcean Kubernetes
-      #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
-      # - name: Verify deployment
-      #   run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment
+      - name: Deploy to DigitalOcean Kubernetes
+        run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
+      - name: Verify deployment
+        run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,28 +15,28 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@main
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      - name: Build truffle-ai-graphql-gateway image
-        run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
-      - name: Build truffle-ai-graphql-server image
-        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
-      - name: Build truffle-ai-repo-job image
-        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
-      - name: Log in to DigitalOcean Container Registry with short-lived credentials
-        run: doctl registry login --expiry-seconds 1200
-      - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
-      - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
-      - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
-        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
-      - name: Save DigitalOcean kubeconfig with short-lived credentials
-        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
-      - name: Create deployment.yml from deployment.template.yml and add environment variables
-        run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
+      # - name: Install doctl
+      #   uses: digitalocean/action-doctl@v2
+      #   with:
+      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      # - name: Build truffle-ai-graphql-gateway image
+      #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
+      # - name: Build truffle-ai-graphql-server image
+      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
+      # - name: Build truffle-ai-repo-job image
+      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
+      # - name: Log in to DigitalOcean Container Registry with short-lived credentials
+      #   run: doctl registry login --expiry-seconds 1200
+      # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
+      # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
+      # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
+      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
+      # - name: Save DigitalOcean kubeconfig with short-lived credentials
+      #   run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
+      # - name: Create deployment.yml from deployment.template.yml and add environment variables
+      #   run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - uses: actions/setup-node@v3
       - name: Update values in deployment file
         run: COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
@@ -48,7 +48,7 @@ jobs:
           CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           node $GITHUB_WORKSPACE/.github/init-deployment.js
-      - name: Deploy to DigitalOcean Kubernetes
-        run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
-      - name: Verify deployment
-        run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment
+      # - name: Deploy to DigitalOcean Kubernetes
+      #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
+      # - name: Verify deployment
+      #   run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,46 +19,56 @@ jobs:
         uses: digitalocean/action-doctl@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      # - name: Build truffle-ai-graphql-gateway image
-      #   run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
-      # - name: Build truffle-ai-graphql-server image
-      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
-      # - name: Build truffle-ai-repo-job image
-      #   run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
+      - name: Build truffle-ai-graphql-gateway image
+        run: docker build --build-arg SERVER_GRAPHQL_URL=${{ vars.SERVER_GRAPHQL_URL }} --build-arg SUPABASE_URL=${{ vars.SUPABASE_URL }} --build-arg SUPABASE_API_KEY=${{ secrets.SUPABASE_API_KEY }} --build-arg SUPABASE_GRAPHQL_URL=${{ vars.SUPABASE_GRAPHQL_URL }} -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_gateway/Dockerfile .
+      - name: Build truffle-ai-graphql-server image
+        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7) -f ./packages/graphql_server/Dockerfile .
+      - name: Build truffle-ai-repo-job image
+        run: docker build -t registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7) -f ./packages/repo_job/Dockerfile .
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
         run: doctl registry login --expiry-seconds 1200
-      # - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
-      # - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
-      # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
-      #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
-      #   CHANGE_CAUSE="$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
-
+      - name: Push truffle-ai-graphql-gateway image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:$(echo $GITHUB_SHA | head -c7)
+      - name: Push truffle-ai-graphql-server image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
+      - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
+        run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - name: Update values in deployment file
-        run: >
-          COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
+        uses: actions/setup-node@v3
+        run: COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')" &&
+          CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
-          echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
-          sed -e
-          's|<CHANGE-CAUSE>|'"${CHANGE_CAUSE}"'|;
-          s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
-          s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
-          s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
-          s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
-          s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
-          $GITHUB_WORKSPACE/config/deployment.yml
+          node ../init-deployment.js
+
+      # - name: Update values in deployment file
+      #   run: >
+      #     COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
+      #     GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
+      #     GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
+      #     GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
+      #     GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
+      #     REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
+      #     CHANGE_CAUSE="$(echo $COMMIT_TAG)\\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | s|["$`\\]|\\&|g | sed 's| *$||g')" &&
+      #     CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
+      #     echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
+      #     sed -e
+      #     's|<CHANGE-CAUSE>|'"${CHANGE_CAUSE}"'|;
+      #     s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
+      #     s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
+      #     s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
+      #     s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
+      #     s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
+      #     s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
+      #     $GITHUB_WORKSPACE/config/deployment.yml
       # - name: Deploy to DigitalOcean Kubernetes
       #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
       # - name: Verify deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g')" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG):\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g')" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'packages/**'
       - '.github/workflows/**'
+      - '.github/init-deployment.js'
       - 'config/deployment.template.yml'
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,28 +48,7 @@ jobs:
           CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           node $GITHUB_WORKSPACE/.github/init-deployment.js
-
-      # - name: Update values in deployment file
-      #   run: >
-      #     COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
-      #     GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
-      #     GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-      #     GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
-      #     GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
-      #     REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-      #     CHANGE_CAUSE="$(echo $COMMIT_TAG)\\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | s|["$`\\]|\\&|g | sed 's| *$||g')" &&
-      #     CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
-      #     echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
-      #     sed -e
-      #     's|<CHANGE-CAUSE>|'"${CHANGE_CAUSE}"'|;
-      #     s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
-      #     s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
-      #     s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
-      #     s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
-      #     s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-      #     s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
-      #     $GITHUB_WORKSPACE/config/deployment.yml
-      # - name: Deploy to DigitalOcean Kubernetes
-      #   run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
-      # - name: Verify deployment
-      #   run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment
+      - name: Deploy to DigitalOcean Kubernetes
+        run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml
+      - name: Verify deployment
+        run: kubectl rollout status --timeout 240s deployment/truffle-ai-deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,14 +40,15 @@ jobs:
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
       - uses: actions/setup-node@v3
       - name: Update values in deployment file
-        run: COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
-          GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
-          GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
-          GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
-          REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})' &&
-          CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
+        run: >
+          COMMIT_TAG='$(echo $GITHUB_SHA | head -c7)'
+          GRAPHQL_GATEWAY_PORT='$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d)'
+          GRAPHQL_SERVER_PORT='$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d)'
+          GRAPHQL_SERVER_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG}'
+          GRAPHQL_GATEWAY_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG}'
+          REPO_JOB_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG}'
+          CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})'
+          CERTIFICATE_ID='$(doctl compute certificate list --format ID --no-header)'
           node $GITHUB_WORKSPACE/.github/init-deployment.js
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,6 @@ jobs:
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
-          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
           s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;'
           $GITHUB_WORKSPACE/config/deployment.yml
       - name: Deploy to DigitalOcean Kubernetes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo "${{ toJSON(github.event.head_commit.message) }}" | tr '\n' ' ' | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d '"' | tr '\n' ' ' | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,14 +46,14 @@ jobs:
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
-          sed -i
+          sed -i ''
           's|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
           s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
-          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;'
+          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|'
           $GITHUB_WORKSPACE/config/deployment.yml
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| |\\ |' | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| |\\ |g' | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,14 @@ jobs:
       - uses: actions/setup-node@v3
       - name: Update values in deployment file
         run: >
-          COMMIT_TAG='$(echo $GITHUB_SHA | head -c7)'
-          GRAPHQL_GATEWAY_PORT='$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d)'
-          GRAPHQL_SERVER_PORT='$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d)'
-          GRAPHQL_SERVER_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG}'
-          GRAPHQL_GATEWAY_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG}'
-          REPO_JOB_IMAGE='registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG}'
-          CHANGE_CAUSE='$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }})'
-          CERTIFICATE_ID='$(doctl compute certificate list --format ID --no-header)'
+          COMMIT_TAG=$(echo $GITHUB_SHA | head -c7)
+          GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d)
+          GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d)
+          GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG}
+          GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG}
+          REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG}
+          COMMIT_MESSAGE=$(echo ${{ toJSON(github.event.head_commit.message) }})
+          CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header)
           node $GITHUB_WORKSPACE/.github/init-deployment.js
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
+          s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
           s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;' >
           $GITHUB_WORKSPACE/config/deployment.yml
       # - name: Deploy to DigitalOcean Kubernetes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:$(echo $GITHUB_SHA | head -c7)
       # - name: Push truffle-ai-repo-job image to DigitalOcean Container Registry
       #   run: docker push registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:$(echo $GITHUB_SHA | head -c7)
+      #   CHANGE_CAUSE="$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
+
       - name: Save DigitalOcean kubeconfig with short-lived credentials
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
@@ -42,10 +44,10 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG)\ $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g' | sed 's|\.|\\.|g')" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
+          CHANGE_CAUSE="test test" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e '

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - META-80-fix-double-quotes
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE='test test' &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG) $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g')" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,11 +47,12 @@ jobs:
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&
-          CHANGE_CAUSE="test\ test" &&
+          CHANGE_CAUSE="test\\ test" &&
           CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) &&
           echo $GRAPHQL_SERVER_IMAGE && echo $GRAPHQL_GATEWAY_IMAGE && echo $REPO_JOB_IMAGE && echo $GRAPHQL_GATEWAY_PORT && echo $GRAPHQL_SERVER_PORT && echo $CHANGE_CAUSE &&
           sed -e
-          's|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
+          's|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
+          s|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|;
           s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|;
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr '\n ' '\\ ' | tr -d \'\"\| | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| |\\ |' | xargs)" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|;
           s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|;
           s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|;
-          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|'
+          s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|;'
           $GITHUB_WORKSPACE/config/deployment.yml
       - name: Deploy to DigitalOcean Kubernetes
         run: kubectl apply -f $GITHUB_WORKSPACE/config/deployment.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,8 @@ jobs:
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 truffle-ai-cluster
       - name: Create deployment.yml from deployment.template.yml and add environment variables
         run: envsubst < $GITHUB_WORKSPACE/config/deployment.template.yml > $GITHUB_WORKSPACE/config/deployment.yml
+      - uses: actions/setup-node@v3
       - name: Update values in deployment file
-        uses: actions/setup-node@v3
         run: COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) &&
           GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) &&
           GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) &&
-          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| |\\ |g' | xargs)" &&
+          CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ${{ toJSON(github.event.head_commit.message) }} | tr -d \'\"\| | tr '\n' ' ' | sed 's| *$||g' | sed 's| |\\ |g')" &&
           GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} &&
           GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} &&
           REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - META-80
+      - META-80-fix-double-quotes
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/config/deployment.template.yml
+++ b/config/deployment.template.yml
@@ -3,8 +3,7 @@ kind: Deployment
 metadata:
   name: truffle-ai-deployment
   annotations:
-    kubernetes.io/change-cause: >
-      <CHANGE-CAUSE>
+    kubernetes.io/change-cause: <CHANGE-CAUSE>
   labels:
     app: truffle-ai-deployment
 spec:

--- a/config/deployment.template.yml
+++ b/config/deployment.template.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: truffle-ai-deployment
   annotations:
-    kubernetes.io/change-cause: <CHANGE-CAUSE>
+    kubernetes.io/change-cause: '<CHANGE-CAUSE>'
   labels:
     app: truffle-ai-deployment
 spec:

--- a/config/deployment.template.yml
+++ b/config/deployment.template.yml
@@ -3,7 +3,8 @@ kind: Deployment
 metadata:
   name: truffle-ai-deployment
   annotations:
-    kubernetes.io/change-cause: <CHANGE-CAUSE>
+    kubernetes.io/change-cause: >
+      <CHANGE-CAUSE>
   labels:
     app: truffle-ai-deployment
 spec:

--- a/config/deployment.template.yml
+++ b/config/deployment.template.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: truffle-ai-deployment
   annotations:
-    kubernetes.io/change-cause: '<CHANGE-CAUSE>'
+    kubernetes.io/change-cause: <CHANGE-CAUSE>
   labels:
     app: truffle-ai-deployment
 spec:


### PR DESCRIPTION
### Description
Adding toJSON caused something like `echo ""[META-80]` in deploy.yml - causing deployment to fail

### How I implemented
removed the double quotes from deploy.yml and rely on the ones from toJSON (we are not able to escape them, so if we use echo we can only have one pair)


see the error
```
COMMIT_TAG=$(echo $GITHUB_SHA | head -c7) && GRAPHQL_GATEWAY_PORT=$(kubectl get secret graphql-gateway-secret --template='{{.data.GATEWAY_PORT}}' | base64 -d) && GRAPHQL_SERVER_PORT=$(kubectl get secret graphql-server-secret --template='{{.data.SERVER_PORT}}' | base64 -d) && CHANGE_CAUSE="$(echo $COMMIT_TAG): $(echo ""[META-80] Fix deployment with sed \n\n[META-80] Fix deployment"" | tr '\n' ' ' | xargs)" && GRAPHQL_SERVER_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-server:${COMMIT_TAG} && GRAPHQL_GATEWAY_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-graphql-gateway:${COMMIT_TAG} && REPO_JOB_IMAGE=registry.digitalocean.com/truffle-ai-containers/truffle-ai-repo-job:${COMMIT_TAG} && CERTIFICATE_ID=$(doctl compute certificate list --format ID --no-header) && sed -i '' 's|<GRAPHQL-SERVER-IMAGE>|'${GRAPHQL_SERVER_IMAGE}'|; s|<GRAPHQL-GATEWAY-IMAGE>|'${GRAPHQL_GATEWAY_IMAGE}'|; s|<REPO-JOB-IMAGE>|'${REPO_JOB_IMAGE}'|; s|<GRAPHQL-GATEWAY-PORT>|'${GRAPHQL_GATEWAY_PORT}'|; s|<GRAPHQL-SERVER-PORT>|'${GRAPHQL_SERVER_PORT}'|; s|<CHANGE-CAUSE>|'${CHANGE_CAUSE}'|; s|<CERTIFICATE-ID>|'${CERTIFICATE_ID}'|' $GITHUB_WORKSPACE/config/deployment.yml
```