### PR TITLE
[BACK-85] Improve manual addition of projects

### DIFF
--- a/packages/graphql_server/src/graphql/commonResponses.ts
+++ b/packages/graphql_server/src/graphql/commonResponses.ts
@@ -1,0 +1,15 @@
+export const REPO_ALREADY_IN_DB_RESPOSE = {
+  message: 'This repo is already in the database.',
+  code: '409'
+}
+
+export const BAD_USER_RESPONSE = {
+  message: 'The graphQL resolver did not receive a valid user.',
+  code: '400',
+  hint: 'Are you loggedIn?'
+}
+
+export const BOOKMARK_DOES_NOT_EXIST_RESPONSE = {
+  message: 'This bookmark does not exist on the database.',
+  code: '409'
+}

--- a/packages/graphql_server/src/graphql/commonResponses.ts
+++ b/packages/graphql_server/src/graphql/commonResponses.ts
@@ -13,3 +13,8 @@ export const BOOKMARK_DOES_NOT_EXIST_RESPONSE = {
   message: 'This bookmark does not exist on the database.',
   code: '409'
 }
+
+export const BAD_URL_RESPONSE = {
+  message: 'The URL you provided is not valid.',
+  code: '400'
+}

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -9,6 +9,15 @@ import { updateAllProjectInfo } from '../../updateProject'
 import { REPO_ALREADY_IN_DB_RESPOSE } from '../commonResponses'
 import { addBookmark } from './bookmark'
 
+/**
+ * Adds a project to the database and bookmarks it for the specified user.
+ * Will not await the fetching of information about the project.
+ * Should usually be called from a addProjectBy<> resolver.
+ * @param {string} repoName - The name of the repo.
+ * @param {string} owner - The name of the owner of the repo.
+ * @param {string} userID - The user ID of the user in question.
+ * @param {string} bookmarkCategory - The category the bookmark should be added to. Not named 'category' because it might not be apparent why an addition needs a category.
+ */
 export const addProject = async (
   repoName: string,
   owner: string,

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -39,7 +39,8 @@ export const addProject = async (
         }
       void addBookmark(userID, projectID, bookmarkCategory)
       return {
-        code: '201'
+        code: '201',
+        message: 'The project was added and bookmarked. We are fetching data for it now.'
       }
     }
   }

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -1,11 +1,12 @@
 import supabase from '../../supabase'
 import { getOrganizationID, getPersonID, repoIsAlreadyInDB } from '../../supabaseUtils'
 import { updateAllProjectInfo } from '../../updateProject'
+import { REPO_ALREADY_IN_DB_RESPOSE } from '../commonResponses'
 import { addBookmark } from './bookmark'
 
 export const addProject = async (repoName: string, owner: string, bookmarkCategory: string) => {
   if (await repoIsAlreadyInDB(repoName, owner)) {
-    return false
+    return REPO_ALREADY_IN_DB_RESPOSE
   } else {
     const { error: insertionError } = await supabase.from('project').insert({
       name: repoName,
@@ -13,13 +14,16 @@ export const addProject = async (repoName: string, owner: string, bookmarkCatego
       owning_person: await getPersonID(owner)
     })
     if (insertionError) {
-      return false
+      return insertionError
     } else {
       // update all the data sources. trending state may be null
+      // add the repo as bookmark immediately
       // no await so that the return happens faster
       void updateAllProjectInfo(repoName, owner, null)
-      void addBookmark(repoName, owner, bookmarkCategory)
-      return true
+      //void addBookmark(repoName, owner, bookmarkCategory)
+      return {
+        code: '201'
+      }
     }
   }
 }

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -14,7 +14,6 @@ export const addProject = async (repoName: string, owner: string, bookmarkCatego
     if (insertionError) {
       return false
     } else {
-      console.log('inserted project', repoName, 'owned by', owner)
       // update all the data sources. trending state may be null
       // no await so that the return happens faster
       void updateAllProjectInfo(repoName, owner, null)

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -1,0 +1,24 @@
+import supabase from '../../supabase'
+import { getOrganizationID, getPersonID, repoIsAlreadyInDB } from '../../supabaseUtils'
+import { updateAllProjectInfo } from '../../updateProject'
+
+export const addProject = async (repoName: string, owner: string, bookmarkCategory: string) => {
+  if (await repoIsAlreadyInDB(repoName, owner)) {
+    return false
+  } else {
+    const { error: insertionError } = await supabase.from('project').insert({
+      name: repoName,
+      owning_organization: await getOrganizationID(owner),
+      owning_person: await getPersonID(owner)
+    })
+    if (insertionError) {
+      return false
+    } else {
+      console.log('inserted project', repoName, 'owned by', owner)
+      // update all the data sources. trending state may be null
+      // no await so that the return happens faster
+      void updateAllProjectInfo(repoName, owner, null)
+      return true
+    }
+  }
+}

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -1,6 +1,7 @@
 import supabase from '../../supabase'
 import { getOrganizationID, getPersonID, repoIsAlreadyInDB } from '../../supabaseUtils'
 import { updateAllProjectInfo } from '../../updateProject'
+import { addBookmark } from './bookmark'
 
 export const addProject = async (repoName: string, owner: string, bookmarkCategory: string) => {
   if (await repoIsAlreadyInDB(repoName, owner)) {
@@ -17,6 +18,7 @@ export const addProject = async (repoName: string, owner: string, bookmarkCatego
       // update all the data sources. trending state may be null
       // no await so that the return happens faster
       void updateAllProjectInfo(repoName, owner, null)
+      void addBookmark(repoName, owner, bookmarkCategory)
       return true
     }
   }

--- a/packages/graphql_server/src/graphql/resolver/bookmark.ts
+++ b/packages/graphql_server/src/graphql/resolver/bookmark.ts
@@ -12,6 +12,6 @@ export const addBookmark = async (userID: string, projectID: string, category: s
   return insertionError
     ? insertionError
     : {
-        code: '204'
+        code: '201'
       }
 }

--- a/packages/graphql_server/src/graphql/resolver/bookmark.ts
+++ b/packages/graphql_server/src/graphql/resolver/bookmark.ts
@@ -1,0 +1,17 @@
+import { bookmarkIsAlreadyInDB, insertBookmark } from '../../supabaseUtils'
+
+export const addBookmark = async (userID: string, projectID: string, category: string) => {
+  if (await bookmarkIsAlreadyInDB(userID, projectID)) {
+    return {
+      message: 'This bookmark is already in the database.',
+      code: '409'
+    }
+  }
+
+  const insertionError = await insertBookmark(projectID, userID, category)
+  return insertionError
+    ? insertionError
+    : {
+        code: '204'
+      }
+}

--- a/packages/graphql_server/src/graphql/resolver/bookmark.ts
+++ b/packages/graphql_server/src/graphql/resolver/bookmark.ts
@@ -1,5 +1,11 @@
 import { bookmarkIsAlreadyInDB, insertBookmark } from '../../supabaseUtils'
 
+/**
+ * Bookmarks a projects for a user.
+ * @param {string} userID - The user ID of the user in question.
+ * @param {string} projectID - The project ID of the project in question.
+ * @param {string} category - The category the bookmark should be added to.
+ */
 export const addBookmark = async (userID: string, projectID: string, category: string) => {
   if (await bookmarkIsAlreadyInDB(userID, projectID)) {
     return {

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -1,16 +1,15 @@
 import { exposeProjectsData } from './resolver/projects'
-import { createProject } from '../dbUpdater'
 import {
   bookmarkIsAlreadyInDB,
   deleteBookmark,
   editBookmarkCategory,
-  insertBookmark,
   renameBookmarkCategory
 } from '../supabaseUtils'
 import { parseGitHubUrl } from '../utils'
 import { MercuriusContext } from 'mercurius'
 import { addProject } from './resolver/addProject'
 import { addBookmark } from './resolver/bookmark'
+import { BAD_USER_RESPONSE, BOOKMARK_DOES_NOT_EXIST_RESPONSE } from './commonResponses'
 
 //@Todo: refine and refactor response types
 
@@ -102,14 +101,3 @@ const resolvers = {
 }
 
 export default resolvers
-
-const BAD_USER_RESPONSE = {
-  message: 'The graphQL resolver did not receive a valid user.',
-  code: '400',
-  hint: 'Are you loggedIn?'
-}
-
-const BOOKMARK_DOES_NOT_EXIST_RESPONSE = {
-  message: 'This bookmark does not exist on the database.',
-  code: '409'
-}

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -10,6 +10,7 @@ import {
 import { parseGitHubUrl } from '../utils'
 import { MercuriusContext } from 'mercurius'
 import { addProject } from './resolver/addProject'
+import { addBookmark } from './resolver/bookmark'
 
 //@Todo: refine and refactor response types
 
@@ -43,19 +44,8 @@ const resolvers = {
         return BAD_USER_RESPONSE
       }
       const userID = context.user?.id
-      if (await bookmarkIsAlreadyInDB(userID, projectID)) {
-        return {
-          message: 'This bookmark is already in the database.',
-          code: '409'
-        }
-      }
 
-      const insertionError = await insertBookmark(projectID, userID, category)
-      return insertionError
-        ? insertionError
-        : {
-            code: '204'
-          }
+      return await addBookmark(userID, projectID, category)
     },
     deleteBookmark: async (
       _parent: unknown,

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -9,7 +9,11 @@ import { parseGitHubUrl } from '../utils'
 import { MercuriusContext } from 'mercurius'
 import { addProject } from './resolver/addProject'
 import { addBookmark } from './resolver/bookmark'
-import { BAD_USER_RESPONSE, BOOKMARK_DOES_NOT_EXIST_RESPONSE } from './commonResponses'
+import {
+  BAD_URL_RESPONSE,
+  BAD_USER_RESPONSE,
+  BOOKMARK_DOES_NOT_EXIST_RESPONSE
+} from './commonResponses'
 
 //@Todo: refine and refactor response types
 
@@ -29,7 +33,7 @@ const resolvers = {
     addProjectByUrl: async (_parent: unknown, { url }: { url: string }) => {
       const urlParts = parseGitHubUrl(url)
       if (urlParts === null) {
-        return false
+        return BAD_URL_RESPONSE
       } else {
         return await addProject(urlParts.repo, urlParts.owner, '')
       }

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -9,6 +9,7 @@ import {
 } from '../supabaseUtils'
 import { parseGitHubUrl } from '../utils'
 import { MercuriusContext } from 'mercurius'
+import { addProject } from './resolver/addProject'
 
 //@Todo: refine and refactor response types
 
@@ -22,7 +23,7 @@ const resolvers = {
   Mutation: {
     // takes in variables. Parent object _ is never used
     addProjectByName: async (_: unknown, { name, owner }: { name: string; owner: string }) => {
-      return await createProject(name, owner, null)
+      return await addProject(name, owner, '')
     },
     // takes in variables. Parent object _parent is never used
     addProjectByUrl: async (_parent: unknown, { url }: { url: string }) => {
@@ -30,7 +31,7 @@ const resolvers = {
       if (urlParts === null) {
         return false
       } else {
-        return await createProject(urlParts.repo, urlParts.owner, null)
+        return await addProject(urlParts.repo, urlParts.owner, '')
       }
     },
     addBookmark: async (

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -26,16 +26,35 @@ const resolvers = {
   },
   Mutation: {
     // takes in variables. Parent object _ is never used
-    addProjectByName: async (_: unknown, { name, owner }: { name: string; owner: string }) => {
-      return await addProject(name, owner, '')
+    addProjectByName: async (
+      _: unknown,
+      { name, owner, bookmarkCategory }: { name: string; owner: string; bookmarkCategory: string },
+      context: MercuriusContext
+    ) => {
+      //Todo: refactor user check
+      if (!context.user) {
+        return BAD_USER_RESPONSE
+      }
+      const userID = context.user?.id
+
+      return await addProject(name, owner, userID, bookmarkCategory)
     },
     // takes in variables. Parent object _parent is never used
-    addProjectByUrl: async (_parent: unknown, { url }: { url: string }) => {
+    addProjectByUrl: async (
+      _parent: unknown,
+      { url, bookmarkCategory }: { url: string; bookmarkCategory: string },
+      context: MercuriusContext
+    ) => {
+      if (!context.user) {
+        return BAD_USER_RESPONSE
+      }
+      const userID = context.user?.id
+
       const urlParts = parseGitHubUrl(url)
       if (urlParts === null) {
         return BAD_URL_RESPONSE
       } else {
-        return await addProject(urlParts.repo, urlParts.owner, '')
+        return await addProject(urlParts.repo, urlParts.owner, userID, bookmarkCategory)
       }
     },
     addBookmark: async (

--- a/packages/graphql_server/src/graphql/resolvers.ts
+++ b/packages/graphql_server/src/graphql/resolvers.ts
@@ -93,7 +93,7 @@ const resolvers = {
 
       const userID = context.user?.id
 
-      //@Todo: check if category exists
+      //@Todo: check if category exists -> future improvement cause not crucial atm
       const renameError = await renameBookmarkCategory(userID, oldCategory, newCategory)
       return renameError ? renameError : { code: '204' }
     }

--- a/packages/graphql_server/src/graphql/schema.ts
+++ b/packages/graphql_server/src/graphql/schema.ts
@@ -5,8 +5,8 @@ const schema = `
     allProjects(first: Int, after: String): ProjectConnection!
   }
   type Mutation {
-    addProjectByName(name: String!, owner: String!): Boolean!
-    addProjectByUrl(url: String!): Boolean!
+    addProjectByName(name: String!, owner: String!): Response!
+    addProjectByUrl(url: String!): Response!
     addBookmark(projectID: String!, category: String!): Response!
     deleteBookmark(projectID: String!): Response!
     editBookmarkCategory(projectID: String!, newCategory: String!): Response!

--- a/packages/graphql_server/src/graphql/schema.ts
+++ b/packages/graphql_server/src/graphql/schema.ts
@@ -5,8 +5,8 @@ const schema = `
     allProjects(first: Int, after: String): ProjectConnection!
   }
   type Mutation {
-    addProjectByName(name: String!, owner: String!): Response!
-    addProjectByUrl(url: String!): Response!
+    addProjectByName(name: String!, owner: String!, bookmarkCategory: String!): Response!
+    addProjectByUrl(url: String!, bookmarkCategory: String!): Response!
     addBookmark(projectID: String!, category: String!): Response!
     deleteBookmark(projectID: String!): Response!
     editBookmarkCategory(projectID: String!, newCategory: String!): Response!


### PR DESCRIPTION
### Description of the issue
The added projects should be bookmarked right away. A status response should be sent earlier.

### How I implemented
- refactored resolvers, so that parts of them are in a separate file
- don't await the fetching of information -> status response sent earlier
- bookmark the project immediately after insertion
- add meaningful return messages

### Other 
Will use this branch as Basis for BACK-86