### PR TITLE
[BACK-93] Fix manual addition of projects

### DIFF
--- a/packages/graphql_server/src/dbUpdater.ts
+++ b/packages/graphql_server/src/dbUpdater.ts
@@ -19,6 +19,7 @@ import {
 } from './supabaseUtils'
 import { fetchTrendingRepos } from './scraping/githubScraping'
 import { TrendingState } from '../types/updateProject'
+import { ProjectInfo } from '../types/supabaseUtils'
 
 /**
  * Updates (and deletes) existing projects and inserts new trending ones.
@@ -57,10 +58,7 @@ export const dailyDbUpdater = async (includeDeletion: boolean) => {
   // here everything that should be updated daily is updated.
   console.log('Updating existing trending and bookmarked projects...')
   for (const project of projectsToBeUpdated) {
-    await updateProjectGithubStats(project.name, project.owner)
-    await updateProjectStarHistory(project.name, project.owner)
-    await updateProjectForkHistory(project.name, project.owner)
-    await updateProjectTweets(project.name, project.owner)
+    await updateProjectDaily(project)
   }
 
   // insert and enrich with data the trending repos
@@ -83,6 +81,17 @@ const processTrendingRepos = async (repos: string[], trendingState: TrendingStat
     // if it is in the database already only the trending state has to be updated
     await createProject(name, owner, trendingState)
   }
+}
+
+/**
+ * Updates all stats for a project, that should be updated daily.
+ * @param {ProjectInfo} project - The project to update
+ */
+export const updateProjectDaily = async (project: ProjectInfo) => {
+  await updateProjectGithubStats(project.name, project.owner)
+  await updateProjectStarHistory(project.name, project.owner)
+  await updateProjectForkHistory(project.name, project.owner)
+  await updateProjectTweets(project.name, project.owner)
 }
 
 /**

--- a/packages/graphql_server/src/graphql/commonResponses.ts
+++ b/packages/graphql_server/src/graphql/commonResponses.ts
@@ -1,4 +1,4 @@
-export const REPO_ALREADY_IN_DB_RESPOSE = {
+export const REPO_ALREADY_IN_DB_RESPONSE = {
   message: 'This repo is already in the database.',
   code: '409'
 }
@@ -17,4 +17,8 @@ export const BOOKMARK_DOES_NOT_EXIST_RESPONSE = {
 export const BAD_URL_RESPONSE = {
   message: 'The URL you provided is not valid.',
   code: '400'
+}
+
+export const INTERNAL_SERVER_ERROR = {
+  code: '500'
 }

--- a/packages/graphql_server/src/graphql/commonResponses.ts
+++ b/packages/graphql_server/src/graphql/commonResponses.ts
@@ -22,3 +22,8 @@ export const BAD_URL_RESPONSE = {
 export const INTERNAL_SERVER_ERROR = {
   code: '500'
 }
+
+export const BOOKMARK_ALREADY_EXISTS_RESPONSE = {
+  message: 'You have already bookmarked this project.',
+  code: '409'
+}

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -1,4 +1,3 @@
-import { PostgrestError } from '@supabase/supabase-js'
 import { updateProjectDaily } from '../../dbUpdater'
 import supabaseClient from '../../supabaseClient'
 import {
@@ -8,7 +7,7 @@ import {
   repoIsAlreadyInDB
 } from '../../supabaseUtils'
 import { updateAllProjectInfo } from '../../updateProject'
-import { INTERNAL_SERVER_ERROR, REPO_ALREADY_IN_DB_RESPONSE } from '../commonResponses'
+import { INTERNAL_SERVER_ERROR } from '../commonResponses'
 import { addBookmark } from './bookmark'
 
 /**

--- a/packages/graphql_server/src/graphql/resolver/bookmark.ts
+++ b/packages/graphql_server/src/graphql/resolver/bookmark.ts
@@ -10,6 +10,8 @@ import {
  * @param {string} projectID - The project ID of the project in question.
  * @param {string} category - The category the bookmark should be added to.
  */
+// @TODO: if the project is not trending or bookmarked the data should be updated, because it might be stale
+// projects can be bookmarked even if not trending, f.e. if they are added manually
 export const addBookmark = async (userID: string, projectID: string, category: string) => {
   if (await bookmarkIsAlreadyInDB(userID, projectID)) {
     return {

--- a/packages/graphql_server/src/graphql/resolver/bookmark.ts
+++ b/packages/graphql_server/src/graphql/resolver/bookmark.ts
@@ -3,6 +3,7 @@ import {
   checkAndUpdateProjectBookmarkedState,
   insertBookmark
 } from '../../supabaseUtils'
+import { BOOKMARK_ALREADY_EXISTS_RESPONSE } from '../commonResponses'
 
 /**
  * Bookmarks a projects for a user.
@@ -14,10 +15,7 @@ import {
 // projects can be bookmarked even if not trending, f.e. if they are added manually
 export const addBookmark = async (userID: string, projectID: string, category: string) => {
   if (await bookmarkIsAlreadyInDB(userID, projectID)) {
-    return {
-      message: 'This bookmark is already in the database.',
-      code: '409'
-    }
+    return BOOKMARK_ALREADY_EXISTS_RESPONSE
   }
 
   const insertionError = await insertBookmark(projectID, userID, category)


### PR DESCRIPTION
### Description of the issue
Right now, the adding projects manually functionality does not work flawlessly. Problems occur, if a project should be added that exists already on the database, but could not be seen by the user because it is not trending. This can be the case if someone else bookmarked the project before or the project was trending before, and is still on the database.

### How I implemented
- bookmark a project if it exists already
- check if the project needs to be updated
- adjusted the response messags

### Other 