### PR TITLE
[BACK-92] Update /graphql_server and add /repo_job README files

### DIFF
--- a/packages/graphql_server/README.md
+++ b/packages/graphql_server/README.md
@@ -2,6 +2,25 @@
 
 A server accessing different services and making them available over graphql
 
+### Structure
+
+in `/src`:
+
+- `/api`: files that only call APIs
+- `/githubHistory`: files responsible for the star, fork and issue history
+- `/graphql`: the graphql resolvers and schema. Some resolvers are refactored into the `/resolver` folder
+- `/scraping`: files that do scraping or that call APIs that do scraping
+- `/test`: tests. Was only put here as a workaround, so that everything in `/src` is located in the top level of `/dist` after compiling. Should be moved somewhere else asap.
+- `/util`: utility function
+- `server.ts` initializes the Fastify server with mercurius
+- `supabaseClient.ts` creates a supabase client that can be used throughout the program
+- `updateProject.ts` contains functions for initiating supabase updates
+- `dbUpdater.ts` contains functionality for updating all entries on the db, which is called by the repo_job
+
+in `/types`:
+
+Types that are needed throughout the program. Types correlated to a file called `fileName.ts` can be found in `fileName.d.ts`
+
 ### Installation
 
 ```bash
@@ -14,6 +33,7 @@ npm ci # installs all dependencies
 npm run dev # runs a dev server
 npm run build # builds the application to ./dist
 npm run serve # serves the build from ./dist
+npm run update-types # updates supabase graphql types into the folder specified in package.json f.e. `/types/supabase.d.ts
 ```
 
 Check [Graphiql](http://localhost:3000/graphiql) with your browser to test the GraphQL server.

--- a/packages/repo_job/README.md
+++ b/packages/repo_job/README.md
@@ -1,0 +1,13 @@
+# repo_job
+
+### What it is for
+
+The repo_job is a cron job that is run as specified in the `deployment.template.yml` file (currently: once every hour).
+It is responsible for updating the database.
+
+### How it works
+
+The `npm run start` script leads to the `index.ts` being run.
+
+In `index.ts` an `axios.get(...)` request is sent to the endpoint of the graphql-server-service, which is specified in the `deployment.template.yml` file. When this endpoint (currently: `/updateDatabase`) is called the database is updated.
+This endpoint can not be called from 3rd parties.


### PR DESCRIPTION
### Description of the issue
The README file of the /graphql_server has to be updated. The README file of the repo_job has to be created.

### How I implemented
- adjusted the /graphql_server README
- created the /repo_job README

### Other
