### PR TITLE
[BACK-95] Fix bookmark deletion bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - BACK-95
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - BACK-95
     paths:
       - 'packages/**'
       - '.github/workflows/**'

--- a/config/deployment.template.yml
+++ b/config/deployment.template.yml
@@ -85,7 +85,7 @@ metadata:
   name: truffle-ai-repo-cronjob
 spec:
   timeZone: 'Europe/Berlin'
-  schedule: '0 * * * *'
+  schedule: '10 * * * *'
   jobTemplate:
     spec:
       template:

--- a/packages/graphql_server/src/graphql/resolver/addProject.ts
+++ b/packages/graphql_server/src/graphql/resolver/addProject.ts
@@ -63,7 +63,7 @@ export const addProject = async (
           code: '500',
           message: 'The project might have been added, but it could not be bookmarked.'
         }
-      void addBookmark(userID, projectID, bookmarkCategory)
+      await addBookmark(userID, projectID, bookmarkCategory)
       return {
         code: '201',
         message: 'The project was added and bookmarked. We are fetching data for it now.'

--- a/packages/graphql_server/src/supabaseUtils.ts
+++ b/packages/graphql_server/src/supabaseUtils.ts
@@ -691,21 +691,17 @@ const updateSupabaseProject = async (
  * @param {string} projectID - The project ID of the project in question.
  */
 const checkAndUpdateProjectBookmarkedState = async (projectID: string) => {
-  console.log('Checking bookmarked state of project with ID', projectID)
   const { data: bookmarkEntries, error } = await supabaseClient
     .from('bookmark')
     .select('*')
     .eq('project_id', projectID)
 
-  console.log('bookmarkentries:', bookmarkEntries)
   if (error) {
     console.error('Error while checking bookmarked state: \n', error)
   } else if (!bookmarkEntries?.[0]) {
-    console.log('changing to false')
     await supabaseClient.from('project').update({ is_bookmarked: false }).eq('id', projectID)
     // check if there is a bookmark entry
   } else if (bookmarkEntries?.[0]) {
-    console.log('changing to true')
     await supabaseClient.from('project').update({ is_bookmarked: true }).eq('id', projectID)
   }
 }

--- a/packages/graphql_server/src/supabaseUtils.ts
+++ b/packages/graphql_server/src/supabaseUtils.ts
@@ -46,7 +46,6 @@ const bookmarkIsAlreadyInDB = async (userID: string, projectID: string) => {
     .select()
     .eq('user_id', userID)
     .eq('project_id', projectID)
-  console.log(data?.length ? true : false)
   return data?.length ? true : false
 }
 
@@ -169,8 +168,7 @@ const formatGithubStats = (githubData: GitHubInfo) => {
     pull_request_count: githubData?.pullRequests?.totalCount,
     github_url: githubData?.url,
     website_url: githubData?.homepageUrl,
-    languages: languages,
-    is_bookmarked: false
+    languages: languages
   }
 }
 
@@ -693,17 +691,21 @@ const updateSupabaseProject = async (
  * @param {string} projectID - The project ID of the project in question.
  */
 const checkAndUpdateProjectBookmarkedState = async (projectID: string) => {
+  console.log('Checking bookmarked state of project with ID', projectID)
   const { data: bookmarkEntries, error } = await supabaseClient
     .from('bookmark')
     .select('*')
     .eq('project_id', projectID)
 
+  console.log('bookmarkentries:', bookmarkEntries)
   if (error) {
     console.error('Error while checking bookmarked state: \n', error)
   } else if (!bookmarkEntries?.[0]) {
+    console.log('changing to false')
     await supabaseClient.from('project').update({ is_bookmarked: false }).eq('id', projectID)
     // check if there is a bookmark entry
   } else if (bookmarkEntries?.[0]) {
+    console.log('changing to true')
     await supabaseClient.from('project').update({ is_bookmarked: true }).eq('id', projectID)
   }
 }

--- a/packages/graphql_server/src/updateProject.ts
+++ b/packages/graphql_server/src/updateProject.ts
@@ -52,7 +52,6 @@ const updateAllProjectInfo = async (
   await updateProjectGithubStats(repoName, owner)
   await updateProjectELI5(repoName, owner)
   await updateProjectFounders(repoName, owner)
-  await updateProjectLinkedInData(owner)
   await updateProjectSentiment(repoName, owner)
   await updateProjectStarHistory(repoName, owner)
   await updateProjectForkHistory(repoName, owner)
@@ -349,7 +348,6 @@ const updateProjectTweets = async (repoName: string, owner: string) => {
     return
   }
 
-  //@Todo: get real fork history -> waiting for jonas' PR to be merged
   const tweets = await getPostsForHashtag(repoName)
 
   await updateSupabaseProject(repoName, owner, { related_twitter_posts: tweets })


### PR DESCRIPTION
### Description of the issue
Non-Trending bookmarks are deleted by the repo_job. That is because the is_bookmarked attribute is updated, but a piece of old code sets the is_bookmarked state to false, when updating the GitHub stats. 

### How I implemented
- removed `is_bookmarked: false` from `formatGithubStats()`

additionally i made the following small adjustments while I was at it:
- changed `void` to `await` when adding bookmark after manual addition. This slightly increases response time but might be needed, if the frontend wants to render new bookmarks right away in the future.
- removed some comments and logs
- removed the linkedIn data fetching method since we canceled our plan

### Other
- I restored the db backup from Saturday evening
- I changed all is_bookmarked states of the currently bookmarked projects to is_bookmarked via a function run on my machine
- I (temporarily) added BACK-95 to the deploy script because the currently deployed version would override the is_bookmarked states again at the next full hour.